### PR TITLE
fix: limit attack count to 100

### DIFF
--- a/src/components/SelectAttackOverlay.tsx
+++ b/src/components/SelectAttackOverlay.tsx
@@ -130,7 +130,7 @@ export const SelectAttackOverlay: FC<SelectAttackOverlayProps> = memo(
                     type="number"
                     value={inputAttackNum}
                     min={0}
-                    max={1000}
+                    max={100} // Limit attack number to 100 to match validation below
                     onChange={e => {
                       const newValue = parseInt(e.target.value);
                       if (newValue <= 0) {


### PR DESCRIPTION
## Summary
- ensure attack count input caps at 100 and document the limit

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f0164c1cc83248ca591ae89e8ece3