### PR TITLE
fix: update attack cards state immutably

### DIFF
--- a/src/components/SelectAttackOverlay.tsx
+++ b/src/components/SelectAttackOverlay.tsx
@@ -25,7 +25,7 @@ export const SelectAttackOverlay: FC<SelectAttackOverlayProps> = memo(
   ({ attackCardIndex, isOpen, onClose }) => {
     const troopData = useTroops();
     const spellData = useSpells();
-    const [attackCards] = useAttackCards();
+    const [attackCards, setAttackCards] = useAttackCards();
 
     const attackCard = attackCards[attackCardIndex];
     const displayCardKey = attackCard.CardKey ? attackCard.CardKey : 'Knight';
@@ -54,11 +54,14 @@ export const SelectAttackOverlay: FC<SelectAttackOverlayProps> = memo(
     };
 
     const handleOnClose = () => {
-      attackCards[attackCardIndex] = {
-        CardKey: inputCardKey,
-        Type: inputType,
-        AttackNumber: inputAttackNum,
-      };
+      setAttackCards({
+        ...attackCards,
+        [attackCardIndex]: {
+          CardKey: inputCardKey,
+          Type: inputType,
+          AttackNumber: inputAttackNum,
+        },
+      });
       onClose();
     };
 


### PR DESCRIPTION
## Summary
- use CardContext state setter when closing the attack card overlay to ensure re-render

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688eff3499508324a6292a47ce6033f8