### PR TITLE
docs: READMEを日本語化

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,35 @@
-# React + TypeScript + Vite
+# CR Tool React
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Clash Royale のバトルをシミュレーションできるウェブアプリです。
+防衛ユニットに対して攻撃側のカードを組み合わせ、総ダメージと残りHPをリアルタイムで計算します。
 
-Currently, two official plugins are available:
+![スクリーンショット](image.png)
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## セットアップ
 
-## Expanding the ESLint configuration
+1. 依存パッケージのインストール
+   ```bash
+   npm install
+   ```
+2. 開発サーバの起動
+   ```bash
+   npm run dev
+   ```
+3. 本番ビルドの作成
+   ```bash
+   npm run build
+   ```
 
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
+## 機能
 
-- Configure the top-level `parserOptions` property like this:
+- 防衛ユニットのHP表示
+- 複数の攻撃カード追加と攻撃回数の設定
+- 総ダメージと残りHPのリアルタイム計算
+- Chakra UI によるレスポンシブなインターフェース
 
-```js
-export default tseslint.config({
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
-```
+## 使用技術
 
-- Replace `tseslint.configs.recommended` to `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
-- Optionally add `...tseslint.configs.stylisticTypeChecked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and update the config:
+- [React](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/)
+- [Vite](https://vitejs.dev/)
+- [Chakra UI](https://chakra-ui.com/)
 
-```js
-// eslint.config.js
-import react from 'eslint-plugin-react'
-
-export default tseslint.config({
-  // Set the react version
-  settings: { react: { version: '18.3' } },
-  plugins: {
-    // Add the react plugin
-    react,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended rules
-    ...react.configs.recommended.rules,
-    ...react.configs['jsx-runtime'].rules,
-  },
-})
-```


### PR DESCRIPTION
## Summary
- README を日本語で書き直し、アプリの目的・セットアップ手順・機能・使用技術を記載
- 誤って改行されていた説明文を修正

## Testing
- `npm test` *(Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f015961a08324bf66c1536d09211c